### PR TITLE
Add support for generating custom poll types

### DIFF
--- a/src/ChunkWriter/ChunkWriter.ts
+++ b/src/ChunkWriter/ChunkWriter.ts
@@ -2,19 +2,36 @@ import { CPPClass, CPPFunction } from 'aclovis';
 
 export abstract class ChunkWriter {
     protected additionalClasses: CPPClass[];
-    protected fxn!: CPPFunction;
+    protected functions: CPPFunction[];
 
     protected constructor() {
         this.additionalClasses = [];
+        this.functions = [];
     }
 
-    getIdentifier(): string {
+    protected get fxn() {
+        return this.functions[0];
+    }
+
+    protected set fxn(value: CPPFunction) {
+        this.functions[0] = value;
+    }
+
+    /**
+     * @todo Remove in 2.0.0
+     * @deprecated Since 1.0.2, ChunkWriters can implement multiple functions, use `getIdentifiers()` instead.
+     */
+    public getIdentifier(): string {
         return this.fxn.getSignature(true).replace(/;$/, '');
     }
 
-    getAdditionalClasses(): CPPClass[] {
+    public getIdentifiers(): string[] {
+        return this.functions.map((value: CPPFunction) => value.getSignature(true).replace(/;$/, ''));
+    }
+
+    public getAdditionalClasses(): CPPClass[] {
         return this.additionalClasses;
     }
 
-    process(): void {}
+    public process(): void {}
 }

--- a/src/ChunkWriter/InitChunk.ts
+++ b/src/ChunkWriter/InitChunk.ts
@@ -6,6 +6,7 @@ import { IEvent } from '../IEvent';
 import { IFlag } from '../IFlag';
 import { IMapObject } from '../IMapObject';
 import IPlugin from '../IPlugin';
+import { IPollType } from '../IPollType';
 import { ISlashCommand } from '../ISlashCommand';
 
 export default class InitChunk extends ChunkWriter {
@@ -26,6 +27,7 @@ export default class InitChunk extends ChunkWriter {
         this.buildBZDBSettingRegistration(fxnBody);
         this.buildFlagRegistration(fxnBody);
         this.buildMapObjectRegistration(fxnBody);
+        this.buildPollTypeRegistration(fxnBody);
 
         this.fxn.implementFunction(fxnBody);
     }
@@ -98,6 +100,15 @@ export default class InitChunk extends ChunkWriter {
             'mapObjects',
             'bz_registerCustomMapObject',
             (object: IMapObject) => [`"${object.name.toUpperCase()}"`, 'this'],
+            body
+        );
+    }
+
+    private buildPollTypeRegistration(body: CPPWritable[]): void {
+        this.registerFunctionRepeater(
+            'pollTypes',
+            'bz_registerCustomPollType',
+            (object: IPollType) => [`"${object.name}"`, 'this'],
             body
         );
     }

--- a/src/ChunkWriter/PollTypeChunk.ts
+++ b/src/ChunkWriter/PollTypeChunk.ts
@@ -1,0 +1,97 @@
+import { CPPClass, CPPFunction, CPPHelper, CPPIfBlock, CPPVariable, CPPWritable, CPPWritableObject } from 'aclovis';
+
+import CPPVisibility from 'aclovis/dist/cpp/CPPVisibility';
+import { ChunkWriter } from './ChunkWriter';
+import IPlugin from '../IPlugin';
+
+export default class PollTypeChunk extends ChunkWriter {
+    private readonly notNeeded: boolean = false;
+
+    private get fxn2() {
+        return this.functions[1];
+    }
+
+    private set fxn2(fxn: CPPFunction) {
+        this.functions[1] = fxn;
+    }
+
+    constructor(pluginClass: CPPClass, private readonly pluginDefinition: IPlugin) {
+        super();
+
+        const pollTypes = Object.keys(pluginDefinition.pollTypes);
+
+        if (pollTypes.length === 0) {
+            this.notNeeded = true;
+            return;
+        }
+
+        pluginClass.addExtends([CPPVisibility.Public, 'bz_CustomPollTypeHandler']);
+
+        this.fxn = new CPPFunction('bool', 'PollOpen', [
+            new CPPVariable('bz_BasePlayerRecord*', 'player'),
+            new CPPVariable('const char*', '_action'),
+            new CPPVariable('const char*', '_parameters'),
+        ]);
+        this.fxn.setVirtual(true);
+        this.fxn.setParentClass(pluginClass, CPPVisibility.Public);
+
+        this.fxn2 = new CPPFunction('void', 'PollClose', [
+            new CPPVariable('const char*', '_action'),
+            new CPPVariable('const char*', '_parameters'),
+            new CPPVariable('bool', 'success'),
+        ]);
+        this.fxn2.setVirtual(true);
+        this.fxn2.setParentClass(pluginClass, CPPVisibility.Public);
+    }
+
+    public process(): void {
+        if (this.notNeeded) {
+            return;
+        }
+
+        const pollOpenBody: CPPWritable[] = [];
+        const pollCloseBody: CPPWritable[] = [];
+
+        this.buildPollOpen(pollOpenBody);
+        this.buildPollClose(pollCloseBody);
+
+        this.fxn.implementFunction(pollOpenBody);
+        this.fxn2.implementFunction(pollCloseBody);
+    }
+
+    private buildPollOpen(body: CPPWritable[]): void {
+        body.push(new CPPVariable('std::string', 'action', '_action'));
+        body.push(CPPHelper.createEmptyLine());
+
+        const ifBlock = new CPPIfBlock();
+
+        for (const pollType in this.pluginDefinition.pollTypes) {
+            ifBlock.defineCondition(`action == "${pollType}"`, [
+                CPPHelper.createEmptyLine(),
+                new CPPWritableObject('return true;'),
+            ]);
+        }
+
+        body.push(ifBlock);
+        body.push(CPPHelper.createEmptyLine());
+        body.push(new CPPWritableObject('return false;'));
+    }
+
+    private buildPollClose(body: CPPWritable[]): void {
+        body.push(new CPPVariable('std::string', 'action', '_action'));
+        body.push(new CPPVariable('std::string', 'parameters', '_parameters'));
+        body.push(CPPHelper.createEmptyLine());
+
+        const ifBlock = new CPPIfBlock();
+
+        for (const pollType in this.pluginDefinition.pollTypes) {
+            const successBlock = new CPPIfBlock();
+            successBlock.defineCondition('success', [CPPHelper.createEmptyLine()]);
+            successBlock.defineElseCondition([CPPHelper.createEmptyLine()]);
+
+            ifBlock.defineCondition(`action == "${pollType}"`, [successBlock]);
+        }
+
+        body.push(ifBlock);
+    }
+}

--- a/src/ChunkWriter/PollTypeChunk.ts
+++ b/src/ChunkWriter/PollTypeChunk.ts
@@ -61,6 +61,7 @@ export default class PollTypeChunk extends ChunkWriter {
 
     private buildPollOpen(body: CPPWritable[]): void {
         body.push(new CPPVariable('std::string', 'action', '_action'));
+        body.push(new CPPVariable('std::string', 'parameters', '_parameters'));
         body.push(CPPHelper.createEmptyLine());
 
         const ifBlock = new CPPIfBlock();

--- a/src/ChunkWriter/__tests__/InitChunk.test.ts
+++ b/src/ChunkWriter/__tests__/InitChunk.test.ts
@@ -162,6 +162,20 @@ void TestClass::Init(const char* config)
 }
         `,
     },
+    {
+        desc: 'Init() should register custom poll types',
+        setup: (def: PluginBuilder) => {
+            def.addPollType({
+                name: 'mapchange',
+            });
+        },
+        expected: `
+void TestClass::Init(const char* config)
+{
+    bz_registerCustomPollType("mapchange", this);
+}
+        `,
+    },
 ];
 
 ITestCodeDefinitionRepeater((c, d) => new InitChunk(c, d), tests);

--- a/src/ChunkWriter/__tests__/PollTypeChunk.test.ts
+++ b/src/ChunkWriter/__tests__/PollTypeChunk.test.ts
@@ -1,0 +1,50 @@
+import { ITestCodeDefinition, ITestCodeDefinitionRepeater } from '../../__tests__/utilities';
+
+import PluginBuilder from '../../PluginBuilder';
+import PollTypeChunk from '../PollTypeChunk';
+
+const tests: ITestCodeDefinition[] = [
+    {
+        desc: 'create a poll type',
+        setup: (def: PluginBuilder) => {
+            def.addPollType({
+                name: 'mapchange',
+            });
+        },
+        expected: `
+bool TestClass::PollOpen(bz_BasePlayerRecord* player, const char* _action, const char* _parameters)
+{
+    std::string action = _action;
+    std::string parameters = _parameters;
+
+    if (action == "mapchange")
+    {
+
+        return true;
+    }
+
+    return false;
+}
+
+void TestClass::PollClose(const char* _action, const char* _parameters, bool success)
+{
+    std::string action = _action;
+    std::string parameters = _parameters;
+
+    if (action == "mapchange")
+    {
+        if (success)
+        {
+
+        }
+        else
+        {
+
+        }
+    }
+}
+        `,
+    },
+];
+
+ITestCodeDefinitionRepeater((c, d) => new PollTypeChunk(c, d), tests);

--- a/src/PluginWriter.ts
+++ b/src/PluginWriter.ts
@@ -7,6 +7,7 @@ import IPlugin from './IPlugin';
 import InitChunk from './ChunkWriter/InitChunk';
 import MapObjectChunk from './ChunkWriter/MapObjectChunk';
 import NameChunk from './ChunkWriter/NameChunk';
+import PollTypeChunk from './ChunkWriter/PollTypeChunk';
 import SlashCommandChunk from './ChunkWriter/SlashCommandChunk';
 
 export default class PluginWriter {
@@ -23,6 +24,7 @@ export default class PluginWriter {
         this.handleEvents();
         this.handleSlashCommands();
         this.handleMapObjects();
+        this.handlePollTypes();
     }
 
     getClassName(): string {
@@ -76,5 +78,10 @@ export default class PluginWriter {
     private handleMapObjects() {
         const mapObjectChunk = new MapObjectChunk(this.pluginClass, this.plugin);
         mapObjectChunk.process();
+    }
+
+    private handlePollTypes() {
+        const pollTypeChunk = new PollTypeChunk(this.pluginClass, this.plugin);
+        pollTypeChunk.process();
     }
 }

--- a/src/__tests__/utilities.ts
+++ b/src/__tests__/utilities.ts
@@ -41,10 +41,15 @@ export const ITestCodeDefinitionRepeater = (
             const chunk = chunkType(pluginClass, pluginDef.definition);
             chunk.process();
 
-            const method = pluginClass.getMethods()[chunk.getIdentifier()];
-            const output = method.functionDef.write(codeStyle, 0);
+            const methods = pluginClass.getMethods();
+            const output: string[] = [];
 
-            expect(output).toEqual(multiLineString(testDef.expected));
+            chunk.getIdentifiers().forEach((value: string) => {
+                const method = methods[value];
+                output.push(method.functionDef.write(codeStyle, 0));
+            });
+
+            expect(output.join('\n\n')).toEqual(multiLineString(testDef.expected));
         });
     }
 };


### PR DESCRIPTION
Apparently I forgot to finish writing this before the 1.0.0 release. :sweat_smile:

Due to the requirement of the poll BZFS API requiring two methods to be implemented, our `ChunkWriter` has been modified to be able to handle more than one method.